### PR TITLE
Strip manufacturer name from device type

### DIFF
--- a/app/services/foreman_netbox/netbox_parameters.rb
+++ b/app/services/foreman_netbox/netbox_parameters.rb
@@ -76,7 +76,9 @@ module ForemanNetbox
     end
 
     def device_type
+      make = manufacturer.dig(:manufacturer, :name)
       model = host.facts.deep_symbolize_keys[:productname] || host.facts.deep_symbolize_keys[:'dmi::product::name'] || UNKNOWN
+      model = model.delete_prefix(make).strip if model.start_with?(make) && model != make
 
       {
         device_type: {


### PR DESCRIPTION
Several manufacturers seem to love prefixing their device identifiers with their name as well, leading to duplicated data otherwise