### PR TITLE
Allow Netbox to own device/site existence

### DIFF
--- a/app/interactors/foreman_netbox/delete_host/delete_device.rb
+++ b/app/interactors/foreman_netbox/delete_host/delete_device.rb
@@ -6,7 +6,7 @@ module ForemanNetbox
       include ::Interactor
 
       around do |interactor|
-        interactor.call unless context.host.compute?
+        interactor.call if !context.host.compute? && Settings[:netbox_delete_devices]
       end
 
       def call

--- a/app/interactors/foreman_netbox/sync_host/sync_device/create.rb
+++ b/app/interactors/foreman_netbox/sync_host/sync_device/create.rb
@@ -8,7 +8,7 @@ module ForemanNetbox
         include ForemanNetbox::Concerns::AssignTags
 
         around do |interactor|
-          interactor.call unless context.device
+          interactor.call if !context.device && Setting[:netbox_create_devices]
         end
 
         def call

--- a/app/interactors/foreman_netbox/sync_host/sync_device/organizer.rb
+++ b/app/interactors/foreman_netbox/sync_host/sync_device/organizer.rb
@@ -11,7 +11,7 @@ module ForemanNetbox
         end
 
         after do
-          context.raw_data[:device] = context.device.raw_data!
+          context.raw_data[:device] = context.device.raw_data! if context.device
         end
 
         organize SyncDevice::Validate,

--- a/app/interactors/foreman_netbox/sync_host/sync_device/sync_interfaces/organizer.rb
+++ b/app/interactors/foreman_netbox/sync_host/sync_device/sync_interfaces/organizer.rb
@@ -7,6 +7,10 @@ module ForemanNetbox
         class Organizer
           include ::Interactor::Organizer
 
+          around do |interactor|
+            interactor.call if context.device
+          end
+
           after do
             context.raw_data[:interfaces] = context.interfaces.reload.raw_data!
           end

--- a/app/interactors/foreman_netbox/sync_host/sync_device/sync_site/organizer.rb
+++ b/app/interactors/foreman_netbox/sync_host/sync_device/sync_site/organizer.rb
@@ -8,7 +8,7 @@ module ForemanNetbox
           include ::Interactor::Organizer
 
           around do |interactor|
-            interactor.call if context.host.location
+            interactor.call if context.host.location && !Setting[:netbox_skip_site_update]
           end
 
           after do

--- a/lib/foreman_netbox/engine.rb
+++ b/lib/foreman_netbox/engine.rb
@@ -61,6 +61,16 @@ module ForemanNetbox
               default: false,
               full_name: N_('Skip Site Update'),
               description: N_('Skip updating Site attribute for Devices')
+            setting 'netbox_create_devices',
+              type: :boolean,
+              default: true,
+              full_name: N_('Create Devices'),
+              description: N_('Create Netbox Device objects for Hosts if they are missing')
+            setting 'netbox_delete_devices',
+              type: :boolean,
+              default: true,
+              full_name: N_('Delete Devices'),
+              description: N_('Delete Device objects on Host deletion')
           end
         end
 


### PR DESCRIPTION
For us, Netbox is the source of truth in regards to device/site existence, so letting Foreman create or delete those objects would break our inventory. This then adds options for if devices should be created or removed, or only found and updated, as well as expanding the site sync variable to skip orchestration of the site objects themselves.

Tests still need to be updated for it, and I'm not sure if the settings are the best delineation. Maybe deletion - as one example - should also support setting the device status to something like Decommissioning/Offline/Inventory instead, to allow marking the hardware as no longer in use on deletion in Foreman.